### PR TITLE
Adds line-height rule to button CSS for IE11.

### DIFF
--- a/src/components/App/components/UserInput/components/Toggle/Toggle.less
+++ b/src/components/App/components/UserInput/components/Toggle/Toggle.less
@@ -11,6 +11,7 @@
   border: 0;
   border-bottom: 1px dashed #000000;
   cursor: pointer;
+  line-height: 1.75rem;
 
   &:focus {
     background-color: @header-background-color;


### PR DESCRIPTION
This change will fix the button height issue referenced in [Issue 59](https://github.com/moroshko/accessible-colors/issues/59)

Firefox:
![firefox](https://user-images.githubusercontent.com/2972688/31578011-6761aa1e-b0de-11e7-9b5c-0fbb46d7210c.png)

IE11:
![ie11](https://user-images.githubusercontent.com/2972688/31578012-677e7bbc-b0de-11e7-8a79-aeced48b9a79.png)

Chrome:
![chrome](https://user-images.githubusercontent.com/2972688/31578013-679a4e1e-b0de-11e7-89f5-dbf99103fefd.png)
